### PR TITLE
Update .NET SDK and target framework to version 9.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "C# (.NET)",
-  "image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:1-9.0",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {
       "installDirectlyFromGitHubRelease": true,

--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -30,4 +30,3 @@ jobs:
       uses: peter-evans/create-pull-request@v7
       with:
         title: Update ShukujitsuData.cs
-

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.101",
     "rollForward": "latestFeature"
   }
 }

--- a/src/ShukujitsuSharp.Generator/ShukujitsuSharp.Generator.csproj
+++ b/src/ShukujitsuSharp.Generator/ShukujitsuSharp.Generator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>ShukujitsuSharp.Generator</RootNamespace>
     <NoWarn>CA2234;CA2007</NoWarn>
   </PropertyGroup>

--- a/src/ShukujitsuSharp.Tests/ShukujitsuSharp.Tests.csproj
+++ b/src/ShukujitsuSharp.Tests/ShukujitsuSharp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CA1707</NoWarn>
   </PropertyGroup>

--- a/src/ShukujitsuSharp/ShukujitsuSharp.csproj
+++ b/src/ShukujitsuSharp/ShukujitsuSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <RootNamespace>ShukujitsuSharp</RootNamespace>
     <Description>ShukujitsuSharp determines japanese holiday.</Description>
     <Authors>SIkebe</Authors>


### PR DESCRIPTION
This pull request includes updates to various project files to upgrade the .NET version from 8.0 to 9.0. The most important changes are listed below:

### Version Upgrades:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L3-R3): Updated the Docker image to use .NET version 9.0.
* [`global.json`](diffhunk://#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bfL3-R3): Updated the SDK version to 9.0.101.
* [`src/ShukujitsuSharp.Generator/ShukujitsuSharp.Generator.csproj`](diffhunk://#diff-5f6cf596d70dc631560c8c0b8eb1ae335fe7cd31ffb43cc8e759f33aedf20c19L5-R5): Changed the target framework to net9.0.
* [`src/ShukujitsuSharp.Tests/ShukujitsuSharp.Tests.csproj`](diffhunk://#diff-570d1bdbc018cb825e257eaec97cfcda4281a94864723c6a656a831c9121f7bdL4-R4): Changed the target framework to net9.0.
* [`src/ShukujitsuSharp/ShukujitsuSharp.csproj`](diffhunk://#diff-7aad32d230ec4aef92a236941a30c22082a266148820a8e0b88e663c2bb23a40L4-R4): Updated the target frameworks to include net9.0 and removed net6.0.

### Minor Changes:

* [`.github/workflows/check-update.yml`](diffhunk://#diff-73e01aa089166ed4072a6514cf296ae75467892706c0520a8480f5c4c4bab9a5L33): Removed an unnecessary blank line.