### PR TITLE
v0.2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
-    <VersionPrefix>0.1.2</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <DebugType>embedded</DebugType>
     <AnalysisLevel>preview</AnalysisLevel>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>


### PR DESCRIPTION
This pull request includes a version update in the `Directory.Build.props` file. The change updates the `VersionPrefix` property from `0.1.2` to `0.2.0`.

* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL5-R5): Updated `VersionPrefix` from `0.1.2` to `0.2.0`.