### PR TITLE
Shukujitsuの祝日判定機能を追加し、関連するテストケースを実装

### DIFF
--- a/src/ShukujitsuSharp.Tests/ShukujitsuSharpTest.cs
+++ b/src/ShukujitsuSharp.Tests/ShukujitsuSharpTest.cs
@@ -72,7 +72,7 @@ public class ShukujitsuSharpTest
     [Fact]
     public void Should_Throw_Exception_For_Invalid_Date()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => Shukujitsu.IsShukujitsu(2021, 2, 20));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Shukujitsu.IsShukujitsu(2021, 2, 30));
         Assert.Throws<ArgumentOutOfRangeException>(() => Shukujitsu.IsShukujitsu(2021, 13, 1));
         Assert.Throws<ArgumentOutOfRangeException>(() => Shukujitsu.IsShukujitsu(0, 1, 1));
     }

--- a/src/ShukujitsuSharp.Tests/ShukujitsuSharpTest.cs
+++ b/src/ShukujitsuSharp.Tests/ShukujitsuSharpTest.cs
@@ -68,4 +68,12 @@ public class ShukujitsuSharpTest
         Assert.IsType<ArgumentOutOfRangeException>(ex3);
         Assert.IsType<ArgumentOutOfRangeException>(ex4);
     }
+
+    [Fact]
+    public void Should_Throw_Exception_For_Invalid_Date()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Shukujitsu.IsShukujitsu(2021, 2, 20));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Shukujitsu.IsShukujitsu(2021, 13, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Shukujitsu.IsShukujitsu(0, 1, 1));
+    }
 }

--- a/src/ShukujitsuSharp.Tests/ShukujitsuSharpTest.cs
+++ b/src/ShukujitsuSharp.Tests/ShukujitsuSharpTest.cs
@@ -21,6 +21,20 @@ public class ShukujitsuSharpTest
     }
 
     [Fact]
+    public void Should_Be_Shukujitsu_With_Year_Month_Day()
+    {
+        var result = Shukujitsu.IsShukujitsu(2021, 1, 1);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Should_Not_Be_Shukujitsu_With_Year_Month_Day()
+    {
+        var result = Shukujitsu.IsShukujitsu(2022, 1, 2);
+        Assert.False(result);
+    }
+
+    [Fact]
     public void Should_Find_Shukujitsu()
     {
         var date = new DateOnly(2022, 1, 1);

--- a/src/ShukujitsuSharp/Shukujitsu.cs
+++ b/src/ShukujitsuSharp/Shukujitsu.cs
@@ -20,6 +20,20 @@ public partial class Shukujitsu
         return Dates.Any(d => d.Date == date);
     }
 
+    /// <summary>
+    /// 指定された日付が祝日（日本の公休日）であるかどうかを判断します。
+    /// </summary>
+    /// <param name="year">日付の年の部分。</param>
+    /// <param name="month">日付の月の部分。</param>
+    /// <param name="day">日付の日の部分。</param>
+    /// <returns>
+    /// 指定された日付が祝日である場合は<c>true</c>。それ以外の場合は<c>false</c>。
+    /// </returns>
+    public static bool IsShukujitsu(int year, int month, int day)
+    {
+        return IsShukujitsu(new DateOnly(year, month, day));
+    }
+
     public static bool Find(DateOnly date, [NotNullWhen(true)] out string? name)
     {
         EnsureAcceptableRange(date);

--- a/src/ShukujitsuSharp/Shukujitsu.cs
+++ b/src/ShukujitsuSharp/Shukujitsu.cs
@@ -33,7 +33,7 @@ public partial class Shukujitsu
     {
         if (year < 1 || month < 1 || month > 12 || day < 1 || day > DateTime.DaysInMonth(year, month))
         {
-            throw new ArgumentOutOfRangeException("引数が適切な年月日の形式ではありません。");
+            throw new ArgumentOutOfRangeException(nameof(year), "引数が適切な年月日の形式ではありません。");
         }
         return IsShukujitsu(new DateOnly(year, month, day));
     }

--- a/src/ShukujitsuSharp/Shukujitsu.cs
+++ b/src/ShukujitsuSharp/Shukujitsu.cs
@@ -31,6 +31,10 @@ public partial class Shukujitsu
     /// </returns>
     public static bool IsShukujitsu(int year, int month, int day)
     {
+        if (year < 1 || month < 1 || month > 12 || day < 1 || day > DateTime.DaysInMonth(year, month))
+        {
+            throw new ArgumentOutOfRangeException("引数が適切な年月日の形式ではありません。");
+        }
         return IsShukujitsu(new DateOnly(year, month, day));
     }
 


### PR DESCRIPTION
This pull request introduces new functionality to the `ShukujitsuSharp` library by adding methods to check if a specific date is a Japanese public holiday using year, month, and day parameters. Additionally, it includes corresponding unit tests to validate this new functionality.

New functionality:

* [`src/ShukujitsuSharp/Shukujitsu.cs`](diffhunk://#diff-d735e579b1ac2c40b51bb3ba8dfe3e1dc8d5bc1576752bfc1d656c44a44e7454R23-R36): Added a new method `IsShukujitsu(int year, int month, int day)` to check if a specific date is a Japanese public holiday using year, month, and day parameters.

Unit tests:

* [`src/ShukujitsuSharp.Tests/ShukujitsuSharpTest.cs`](diffhunk://#diff-0d4135318ba0e8adfd6062906fd2e29f6a57f718e8095b4155854fbce1e18050R23-R36): Added unit tests `Should_Be_Shukujitsu_With_Year_Month_Day` and `Should_Not_Be_Shukujitsu_With_Year_Month_Day` to validate the new `IsShukujitsu` method.