### PR TITLE
Shukujitsuの祝日判定機能を追加し、テストケースを実装

### DIFF
--- a/src/ShukujitsuSharp.Tests/ShukujitsuSharpTest.cs
+++ b/src/ShukujitsuSharp.Tests/ShukujitsuSharpTest.cs
@@ -54,4 +54,18 @@ public class ShukujitsuSharpTest
         Assert.IsType<ArgumentOutOfRangeException>(ex3);
         Assert.IsType<ArgumentOutOfRangeException>(ex4);
     }
+
+    [Fact]
+    public void Should_Be_Shukujitsu_With_Year_Month_Day()
+    {
+        var result = Shukujitsu.IsShukujitsu(2021, 1, 1); // 修正: 正しい祝日の日付を使用
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Should_Not_Be_Shukujitsu_With_Year_Month_Day()
+    {
+        var result = Shukujitsu.IsShukujitsu(2022, 1, 2);
+        Assert.False(result);
+    }
 }

--- a/src/ShukujitsuSharp/Shukujitsu.cs
+++ b/src/ShukujitsuSharp/Shukujitsu.cs
@@ -20,6 +20,19 @@ public partial class Shukujitsu
         return Dates.Any(d => d.Date == date);
     }
 
+
+    /// <summary>
+    /// 指定された年、月、日が祝日かどうかを判定します。
+    /// </summary>
+    /// <param name="year">年を表す整数。</param>
+    /// <param name="month">月を表す整数。</param>
+    /// <param name="day">日を表す整数。</param>
+    /// <returns>指定された日付が祝日の場合は true、それ以外の場合は false。</returns>
+    public static bool IsShukujitsu(int year, int month, int day)
+    {
+        return IsShukujitsu(new DateOnly(year, month, day));
+    }
+
     public static bool Find(DateOnly date, [NotNullWhen(true)] out string? name)
     {
         EnsureAcceptableRange(date);


### PR DESCRIPTION
This pull request introduces new functionality to the `ShukujitsuSharp` library, allowing users to check if a specific date is a holiday by providing the year, month, and day as separate parameters. Additionally, new tests have been added to ensure the correctness of this functionality.

New functionality:

* [`src/ShukujitsuSharp/Shukujitsu.cs`](diffhunk://#diff-d735e579b1ac2c40b51bb3ba8dfe3e1dc8d5bc1576752bfc1d656c44a44e7454R23-R35): Added a new method `IsShukujitsu(int year, int month, int day)` to check if a specified date is a holiday by using separate year, month, and day parameters.

New tests:

* [`src/ShukujitsuSharp.Tests/ShukujitsuSharpTest.cs`](diffhunk://#diff-0d4135318ba0e8adfd6062906fd2e29f6a57f718e8095b4155854fbce1e18050R57-R70): Added two new test methods, `Should_Be_Shukujitsu_With_Year_Month_Day` and `Should_Not_Be_Shukujitsu_With_Year_Month_Day`, to verify the new functionality for checking holidays with separate year, month, and day parameters.