### PR TITLE
祝日判定機能のテストを追加し、テストデータを修正

### DIFF
--- a/src/ShukujitsuSharp.Tests/ShukujitsuSharpTest.cs
+++ b/src/ShukujitsuSharp.Tests/ShukujitsuSharpTest.cs
@@ -21,6 +21,20 @@ public class ShukujitsuSharpTest
     }
 
     [Fact]
+    public void Should_Be_Shukujitsu_With_Year_Month_Day()
+    {
+        var result = Shukujitsu.IsShukujitsu(2021, 1, 1);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Should_Not_Be_Shukujitsu_With_Year_Month_Day()
+    {
+        var result = Shukujitsu.IsShukujitsu(2022, 1, 2); // 修正: テストデータを祝日ではない日付に変更
+        Assert.False(result);
+    }
+
+    [Fact]
     public void Should_Find_Shukujitsu()
     {
         var date = new DateOnly(2022, 1, 1);

--- a/src/ShukujitsuSharp/Shukujitsu.cs
+++ b/src/ShukujitsuSharp/Shukujitsu.cs
@@ -20,6 +20,11 @@ public partial class Shukujitsu
         return Dates.Any(d => d.Date == date);
     }
 
+    public static bool IsShukujitsu(int year, int month, int day)
+    {
+        return IsShukujitsu(new DateOnly(year, month, day));
+    }
+
     public static bool Find(DateOnly date, [NotNullWhen(true)] out string? name)
     {
         EnsureAcceptableRange(date);


### PR DESCRIPTION
This pull request introduces new functionality to the `ShukujitsuSharp` library and its associated tests. The most important changes include the addition of a new method to check for holidays using year, month, and day parameters, and new tests to verify this functionality.

New functionality:

* [`src/ShukujitsuSharp/Shukujitsu.cs`](diffhunk://#diff-d735e579b1ac2c40b51bb3ba8dfe3e1dc8d5bc1576752bfc1d656c44a44e7454R23-R27): Added a new method `IsShukujitsu(int year, int month, int day)` to check if a specific date is a holiday by accepting year, month, and day as parameters.

New tests:

* [`src/ShukujitsuSharp.Tests/ShukujitsuSharpTest.cs`](diffhunk://#diff-0d4135318ba0e8adfd6062906fd2e29f6a57f718e8095b4155854fbce1e18050R23-R36): Added new test methods `Should_Be_Shukujitsu_With_Year_Month_Day` and `Should_Not_Be_Shukujitsu_With_Year_Month_Day` to verify the new `IsShukujitsu` method with year, month, and day parameters.